### PR TITLE
Fix all DeprecationWarning: invalid escape sequence

### DIFF
--- a/source_py2/python_toolbox/address_tools/shared.py
+++ b/source_py2/python_toolbox/address_tools/shared.py
@@ -7,13 +7,13 @@ import re
 
 
 _address_pattern = re.compile(
-    "^(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)$"
+    r"^(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)$"
 )
 '''Pattern for Python addresses, like 'email.encoders'.'''
 
 
 _contained_address_pattern = re.compile(
-    "(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)"
+    r"(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)"
 )
 '''
 Pattern for strings containing Python addresses, like '{email.encoders: 1}'.

--- a/source_py2/python_toolbox/address_tools/string_to_object.py
+++ b/source_py2/python_toolbox/address_tools/string_to_object.py
@@ -73,7 +73,7 @@ def resolve(string, root=None, namespace={}):
     
 
 def get_object_by_address(address, root=None, namespace={}):
-    '''
+    r'''
     Get an object by its address.
     
     For example:

--- a/source_py2/python_toolbox/third_party/decorator.py
+++ b/source_py2/python_toolbox/third_party/decorator.py
@@ -77,7 +77,7 @@ def getargspec(f):
     spec = getfullargspec(f)
     return ArgSpec(spec.args, spec.varargs, spec.varkw, spec.defaults)
 
-DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
+DEF = re.compile(r'\s*def\s*([_\w][_\w\d]*)\s*\(')
 
 
 # basic functionality

--- a/source_py2/test_python_toolbox/test_cute_testing/test_raise_assertor.py
+++ b/source_py2/test_python_toolbox/test_cute_testing/test_raise_assertor.py
@@ -82,7 +82,7 @@ def test_regex():
     '''
     Test using `RaiseAssertor` specifying regex pattern for exception message.
     '''
-    with RaiseAssertor(Exception, re.compile('^123\w*?456$')):
+    with RaiseAssertor(Exception, re.compile(r'^123\w*?456$')):
         raise TypeError('123qwerty456')
     
     with RaiseAssertor(Failure):
@@ -90,7 +90,7 @@ def test_regex():
             raise TypeError('123qwerty456')
         
     with RaiseAssertor(Failure):
-        with RaiseAssertor(OSError, re.compile('^123\w*?456$')):
+        with RaiseAssertor(OSError, re.compile(r'^123\w*?456$')):
             raise SyntaxError('123qwerty456')
         
 

--- a/source_py2/test_python_toolbox/test_nifty_collections/test_bagging.py
+++ b/source_py2/test_python_toolbox/test_nifty_collections/test_bagging.py
@@ -79,7 +79,7 @@ class BaseBagTestCase(cute_testing.TestCase):
         with cute_testing.RaiseAssertor(TypeError):
             - bag
         
-        assert re.match('^(Frozen)?(Ordered)?Bag\(.*$', repr(bag))
+        assert re.match(r'^(Frozen)?(Ordered)?Bag\(.*$', repr(bag))
         
         assert bag.copy() == bag
         

--- a/source_py2/test_python_toolbox/test_re_tools.py
+++ b/source_py2/test_python_toolbox/test_re_tools.py
@@ -12,5 +12,5 @@ from python_toolbox.re_tools import searchall
 def test_searchall():
     '''Test the basic workings of `searchall`.'''
     s = 'asdf df sfg s'
-    result = searchall('(\w+)', s)
+    result = searchall(r'(\w+)', s)
     assert len(result) == 4

--- a/source_py3/python_toolbox/address_tools/shared.py
+++ b/source_py3/python_toolbox/address_tools/shared.py
@@ -7,13 +7,13 @@ import re
 
 
 _address_pattern = re.compile(
-    "^(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)$"
+    r"^(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)$"
 )
 '''Pattern for Python addresses, like 'email.encoders'.'''
 
 
 _contained_address_pattern = re.compile(
-    "(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)"
+    r"(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)"
 )
 '''
 Pattern for strings containing Python addresses, like '{email.encoders: 1}'.

--- a/source_py3/python_toolbox/address_tools/string_to_object.py
+++ b/source_py3/python_toolbox/address_tools/string_to_object.py
@@ -73,7 +73,7 @@ def resolve(string, root=None, namespace={}):
     
 
 def get_object_by_address(address, root=None, namespace={}):
-    '''
+    r'''
     Get an object by its address.
     
     For example:

--- a/source_py3/python_toolbox/file_tools.py
+++ b/source_py3/python_toolbox/file_tools.py
@@ -48,7 +48,7 @@ def _get_next_path(path):
 
 
 def iterate_file_paths(path):
-    '''
+    r'''
     Iterate over file paths, hoping to find one that's available.
     
     For example, when given "c:\example.ogg", would first yield

--- a/source_py3/python_toolbox/third_party/decorator.py
+++ b/source_py3/python_toolbox/third_party/decorator.py
@@ -77,7 +77,7 @@ def getargspec(f):
     spec = getfullargspec(f)
     return ArgSpec(spec.args, spec.varargs, spec.varkw, spec.defaults)
 
-DEF = re.compile('\s*def\s*([_\w][_\w\d]*)\s*\(')
+DEF = re.compile(r'\s*def\s*([_\w][_\w\d]*)\s*\(')
 
 
 # basic functionality

--- a/source_py3/test_python_toolbox/test_cute_testing/test_raise_assertor.py
+++ b/source_py3/test_python_toolbox/test_cute_testing/test_raise_assertor.py
@@ -82,7 +82,7 @@ def test_regex():
     '''
     Test using `RaiseAssertor` specifying regex pattern for exception message.
     '''
-    with RaiseAssertor(Exception, re.compile('^123\w*?456$')):
+    with RaiseAssertor(Exception, re.compile(r'^123\w*?456$')):
         raise TypeError('123qwerty456')
     
     with RaiseAssertor(Failure):
@@ -90,7 +90,7 @@ def test_regex():
             raise TypeError('123qwerty456')
         
     with RaiseAssertor(Failure):
-        with RaiseAssertor(OSError, re.compile('^123\w*?456$')):
+        with RaiseAssertor(OSError, re.compile(r'^123\w*?456$')):
             raise SyntaxError('123qwerty456')
         
 

--- a/source_py3/test_python_toolbox/test_nifty_collections/test_bagging.py
+++ b/source_py3/test_python_toolbox/test_nifty_collections/test_bagging.py
@@ -72,7 +72,7 @@ class BaseBagTestCase(cute_testing.TestCase, metaclass=abc.ABCMeta):
         with cute_testing.RaiseAssertor(TypeError):
             - bag
         
-        assert re.match('^(Frozen)?(Ordered)?Bag\(.*$', repr(bag))
+        assert re.match(r'^(Frozen)?(Ordered)?Bag\(.*$', repr(bag))
         
         assert bag.copy() == bag
         

--- a/source_py3/test_python_toolbox/test_re_tools.py
+++ b/source_py3/test_python_toolbox/test_re_tools.py
@@ -12,5 +12,5 @@ from python_toolbox.re_tools import searchall
 def test_searchall():
     '''Test the basic workings of `searchall`.'''
     s = 'asdf df sfg s'
-    result = searchall('(\w+)', s)
+    result = searchall(r'(\w+)', s)
     assert len(result) == 4


### PR DESCRIPTION
Hello,

This is the last patch for this kind of warnings, they should be all fixed now:
```python
source_py2/python_toolbox/address_tools/shared.py:10: DeprecationWarning: invalid escape sequence \.
  "^(?P<address>([a-zA-Z_][0-9a-zA-Z_]*)(\.[a-zA-Z_][0-9a-zA-Z_]*)*)$"
```
I used this command to track them down:
```shell
python3 -Wall -m compileall -q -f *
```

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>