### PR TITLE
docs: Fix a few typos

### DIFF
--- a/python_toolbox/address_tools/object_to_string.py
+++ b/python_toolbox/address_tools/object_to_string.py
@@ -19,12 +19,12 @@ from .shared import (_address_pattern, _contained_address_pattern,
 
 
 _unresolvable_string_pattern = re.compile("<[^<>]*?'[^<>]*?'[^<>]*?>")
-'''Pattern for unresorvable strings, like "<type 'list'>".'''
+'''Pattern for unresolvable strings, like "<type 'list'>".'''
 
 
 _address_in_unresolvable_string_pattern = re.compile("[^']*?'([^']*?)'[^']*?")
 '''
-Pattern for extracting address from unresorvable strings.
+Pattern for extracting address from unresolvable strings.
 
 For example, matching "type 'list'" would result in `match.groups() ==
 ('list',)`.

--- a/python_toolbox/wx_tools/colors.py
+++ b/python_toolbox/wx_tools/colors.py
@@ -41,7 +41,7 @@ def get_background_color():
     elif is_mac:
         return wx.Colour(232, 232, 232)
     elif is_gtk:
-        # Until `SYS_COLOUR_*` get their act togother, we're using Windows
+        # Until `SYS_COLOUR_*` get their act together, we're using Windows
         # colors for Linux.
         return wx.Colour(212, 208, 200)
 

--- a/python_toolbox/wx_tools/widgets/third_party/customtreectrl.py
+++ b/python_toolbox/wx_tools/widgets/third_party/customtreectrl.py
@@ -7409,7 +7409,7 @@ class CustomTreeCtrl(wx.PyScrolledWindow):
         rect = self.GetBoundingRect(root, True)
 
         # It looks like the space between the "+" and the node
-        # rect occupies 4 pixels approximatively
+        # rect occupies 4 pixels approximately
         maxwidth = rect.x + rect.width + 4
         lastheight = rect.y + rect.height
 
@@ -7446,7 +7446,7 @@ class CustomTreeCtrl(wx.PyScrolledWindow):
             rect = self.GetBoundingRect(child, True)
 
             # It looks like the space between the "+" and the node
-            # rect occupies 4 pixels approximatively
+            # rect occupies 4 pixels approximately
             maxwidth = max(maxwidth, rect.x + rect.width + 4)
             lastheight = rect.y + rect.height
 

--- a/test_python_toolbox/test_address_tools/test_describe.py
+++ b/test_python_toolbox/test_address_tools/test_describe.py
@@ -12,7 +12,7 @@ import python_toolbox
 from python_toolbox.address_tools import describe, resolve
 
 # todo: Make test that when a root or namespace is given, it's top priority to
-# use it, even if it prevents shorterning and results in an overall longer
+# use it, even if it prevents shortening and results in an overall longer
 # address.
 
 


### PR DESCRIPTION
There are small typos in:
- python_toolbox/address_tools/object_to_string.py
- python_toolbox/wx_tools/colors.py
- python_toolbox/wx_tools/widgets/third_party/customtreectrl.py
- test_python_toolbox/test_address_tools/test_describe.py

Fixes:
- Should read `unresolvable` rather than `unresorvable`.
- Should read `approximately` rather than `approximatively`.
- Should read `together` rather than `togother`.
- Should read `shortening` rather than `shorterning`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md